### PR TITLE
Deprecate xivo-provd-cli

### DIFF
--- a/bin/wazo-provd-cli
+++ b/bin/wazo-provd-cli
@@ -1,7 +1,3 @@
-#!/bin/sh
+#!/usr/bin/env python
 
-if [ -z "$PYTHON" ]; then
-    PYTHON=python
-fi
-
-"$PYTHON" -m wazo_provd_cli.cli "$@"
+from wazo_provd_cli import cli

--- a/debian/wazo-provd-cli.links
+++ b/debian/wazo-provd-cli.links
@@ -1,0 +1,1 @@
+usr/bin/wazo-provd-cli usr/bin/xivo-provd-cli

--- a/wazo_provd_cli/cli.py
+++ b/wazo_provd_cli/cli.py
@@ -59,6 +59,11 @@ else:
     host = args[0]
 
 
+if sys.argv[0].endswith('xivo-provd-cli'):
+    print(
+        'Warning: xivo-provd-cli is a deprecated alias to wazo-provd-cli. Use wazo-provd-cli instead'
+    )
+
 def _bool(value):
     if value in ['True', 'true', '1']:
         return True


### PR DESCRIPTION
Instead of deleting it altogether. Reason is that probably a lot of scripts are using it.